### PR TITLE
Add option to disable debug output even if process.env.DEBUG is true

### DIFF
--- a/examples/deflated-stream.js
+++ b/examples/deflated-stream.js
@@ -1,3 +1,4 @@
+process.env.DEBUG = true;
 var fs     = require('fs'),
     stream = require('stream'),
     needle = require('./../');

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -119,6 +119,10 @@ var Needle = {
       }
     }
 
+    if(!options.printDebugLogs){
+      debug = function() { /* noop */ };;
+    }
+
     if (data) {
       if (method.toUpperCase() == 'GET') { // build query string and append to URI
 

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -119,7 +119,7 @@ var Needle = {
       }
     }
 
-    if(!options.printDebugLogs){
+    if(options.hasOwnProperty('printDebugLogs') && !options.printDebugLogs){
       debug = function() { /* noop */ };;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "needle",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Tiny yet feature-packed HTTP client. With multipart, charset decoding and proxy support.",
   "keywords": [
     "http",


### PR DESCRIPTION
This is the first PR in reference to https://github.com/clearbit/clearbit-node/issues/31

This provides a new option, `printDebugLogs`, that when set to false does not print any debug logs, regardless of the environment variable `DEBUG`.